### PR TITLE
v0.6.2 ready for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # PSProfile - ChangeLog
 
 * [PSProfile - ChangeLog](#psprofile---changelog)
+    * [0.6.2 - 2020-05-14](#062---2020-05-14)
     * [0.6.1 - 2019-11-04](#061---2019-11-04)
     * [0.6.0 - 2019-11-02](#060---2019-11-02)
     * [0.5.0 - 2019-10-08](#050---2019-10-08)
@@ -20,6 +21,13 @@
     * [0.1.0 - 2019-08-19](#010---2019-08-19)
 
 ***
+
+## 0.6.2 - 2020-05-14
+
+* Miscellaneous
+    * Fixed: `PSProfile.ADCompleters` plugin now correctly tab completes properties for `Get-ADComputer` and `Get-ADGroup`
+    * Added: InitScripts, ScriptPaths, and Plugins now create a dynamic module per item for easier discovery of where the command came from.
+    * Updated: `Get-PSProfileImportedCommands` logic so it pulls in commands from any module named `PSProfile.*`, which includes the changes to InitScripts, ScriptPaths, and Plugins where they are now loaded in as dynamic modules.
 
 ## 0.6.1 - 2019-11-04
 

--- a/PSProfile/Plugins/PSProfile.ADCompleters.ps1
+++ b/PSProfile/Plugins/PSProfile.ADCompleters.ps1
@@ -1,4 +1,3 @@
-
 Register-ArgumentCompleter -CommandName 'Get-ADUser' -ParameterName 'Properties' -ScriptBlock {
     param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
     @(
@@ -142,6 +141,7 @@ Register-ArgumentCompleter -CommandName 'Get-ADUser' -ParameterName 'Properties'
 }
 
 Register-ArgumentCompleter -CommandName 'Get-ADComputer' -ParameterName 'Properties' -ScriptBlock {
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
     @(
         'AccountExpirationDate'
         'accountExpires'
@@ -243,6 +243,7 @@ Register-ArgumentCompleter -CommandName 'Get-ADComputer' -ParameterName 'Propert
 }
 
 Register-ArgumentCompleter -CommandName 'Get-ADGroup' -ParameterName 'Properties' -ScriptBlock {
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
     @(
         'AddedProperties'
         'CanonicalName'

--- a/PSProfile/Public/Meta/Get-PSProfileImportedCommand.ps1
+++ b/PSProfile/Public/Meta/Get-PSProfileImportedCommand.ps1
@@ -22,7 +22,7 @@ function Get-PSProfileImportedCommand {
         $Command
     )
     Begin {
-        $commands = Get-Command -Module PSProfile | Where-Object {$_.Name -notin (Get-Module PSProfile).ExportedCommands.Keys}
+        $commands = Get-Command -Module PSProfile.* #| Where-Object {$_.Name -notin (Get-Module PSProfile).ExportedCommands.Keys}
     }
     Process {
         if ($PSBoundParameters.ContainsKey('Command')) {


### PR DESCRIPTION
## 0.6.2 - 2020-05-14

* Miscellaneous
    * Fixed: `PSProfile.ADCompleters` plugin now correctly tab completes properties for `Get-ADComputer` and `Get-ADGroup`
    * Added: InitScripts, ScriptPaths, and Plugins now create a dynamic module per item for easier discovery of where the command came from.
    * Updated: `Get-PSProfileImportedCommands` logic so it pulls in commands from any module named `PSProfile.*`, which includes the changes to InitScripts, ScriptPaths, and Plugins where they are now loaded in as dynamic modules.