### PR TITLE
Fixed ipmo error message and links in README.md

### DIFF
--- a/PSProfile/Classes/PSProfile.Classes.ps1
+++ b/PSProfile/Classes/PSProfile.Classes.ps1
@@ -919,7 +919,7 @@ if ($env:AWS_PROFILE) {
                 }
                 catch {
                     $this._log(
-                        "'$($params['Name'])' Error importing module: $($Error[0].Exception.Message)",
+                        "'$($params['Name'])' Error importing module: $($_.Exception.Message)",
                         "ImportModules",
                         "Warning"
                     )

--- a/README.md
+++ b/README.md
@@ -45,17 +45,17 @@ PSProfile is a cross-platform PowerShell module built for profile customization.
 </div>
 <br />
 
-* [PSProfile](#psprofile)
-  * [Background](#background)
-  * [Quick Start](#quick-start)
-  * [Getting Help](#getting-help)
-  * [Tips & Tricks](#tips--tricks)
-    * [ProjectPaths](#projectpaths)
-    * [ScriptPaths](#scriptpaths)
-  * [Contributing](#contributing)
-  * [Code of Conduct](#code-of-conduct)
-  * [License](#license)
-  * [Changelog](#changelog)
+- [PSProfile](#psprofile)
+  - [Background](#background)
+  - [Quick Start](#quick-start)
+  - [Getting Help](#getting-help)
+  - [Tips & Tricks](#tips--tricks)
+    - [ProjectPaths](#projectpaths)
+    - [ScriptPaths](#scriptpaths)
+  - [Contributing](#contributing)
+  - [Code of Conduct](#code-of-conduct)
+  - [License](#license)
+  - [Changelog](#changelog)
 
 ## Background
 
@@ -177,7 +177,7 @@ This adds the script specified to `$PSProfile.ScriptPaths`. Any scripts here wil
 
 ## Contributing
 
-Interested in helping out with PSProfile development? Please check out our [Contribution Guidelines](https://github.com/scrthq/PSProfile/blob/master/CONTRIBUTING.md)!
+Interested in helping out with PSProfile development? Please check out our [Contribution Guidelines](https://github.com/scrthq/PSProfile/blob/main/CONTRIBUTING.md)!
 
 Building the module locally to test changes is as easy as running the `build.ps1` file in the root of the repo. This will compile the module with your changes and import the newly compiled module at the end by default.
 
@@ -189,7 +189,7 @@ Want to run the Pester tests locally? Pass `Test` as the value to the `Task` scr
 
 ## Code of Conduct
 
-Please adhere to our [Code of Conduct](https://github.com/scrthq/PSProfile/blob/master/CODE_OF_CONDUCT.md) when interacting with this repo.
+Please adhere to our [Code of Conduct](https://github.com/scrthq/PSProfile/blob/main/CODE_OF_CONDUCT.md) when interacting with this repo.
 
 ## License
 
@@ -197,4 +197,4 @@ Please adhere to our [Code of Conduct](https://github.com/scrthq/PSProfile/blob/
 
 ## Changelog
 
-[Full CHANGELOG here](https://github.com/scrthq/PSProfile/blob/master/CHANGELOG.md)
+[Full CHANGELOG here](https://github.com/scrthq/PSProfile/blob/main/CHANGELOG.md)


### PR DESCRIPTION
- Fixed broken link in README due to master -> main
- Fixed blank error message from the `Import-Module` call for the `ModulesToImport` key. `$error` seemed to be null at that point so I just changed it to reference psitem instead, seems to work.
- I didn't bump the version number because I wasn't sure if it was still required? When I ran `build.ps1` it read from somewhere what the latest already was (presumably the gallery?) and just bumped it by one. So I left it as `0.6.0` in the manifest.

Question ... In the CONTRIBUTING.md file you provide a snippet to put in our profiles. You suggest we can open our console's working directory to be of the git/project directory from within our editor (presumably vscode). How do I do this in vscode? 

Regardless I did make the below as I was testing just by right clicking in File Explorer while holding shift and chose `Open PowerShell window here...` (Windows PowerShell 5.1). But that is when I learnt the current working directory is `C:\Windows` while the profile loads via this method, so the relative reference to `.\BuildOutput\PSProfile` is not true at that point. So not only is the below fugly as hell, but also a waste of time in hindsight lol. Ping me on Discord if it doesn't make sense.

```powershell
$PSProfileBuildOutput = Get-ChildItem '.\BuildOutput\PSProfile' -ErrorAction SilentlyContinue

$module = if ($PSProfileBuildOutput) {
    $PSProfileBuildOutput | Sort-Object -Property CreationTime | Select-Object -First 1 | ForEach-Object {
        try {
            Import-Module $_ -ErrorAction Stop
        }
        catch {
            Write-Warning "Error(s) when importing PSProfile from the BuildOutput folder:`n$($Error[0])`nFalling back to installed version"
            Import-Module PSProfile
        }
    }
}
else {
    Import-MOdule PSProfile
}
```